### PR TITLE
Various Updates

### DIFF
--- a/include/simulated_lidar_scanner/lidar_scanner_simulator.h
+++ b/include/simulated_lidar_scanner/lidar_scanner_simulator.h
@@ -33,7 +33,7 @@ struct ScannerParams
 class LidarScannerSim
 {
 public:
-  LidarScannerSim(const ScannerParams& sim);
+  LidarScannerSim(const ScannerParams& sim, const bool z_out);
 
   inline void setScannerScene(const vtkSmartPointer<vtkPolyData>& scene)
   {
@@ -55,6 +55,8 @@ public:
   }
 
 private:
+  const bool z_out_;
+
   vtkSmartPointer<vtkLidarScanner> scanner_;
   vtkSmartPointer<vtkPolyData> scan_data_vtk_;
   pcl::PointCloud<pcl::PointNormal>::Ptr scan_data_cloud_;

--- a/launch/start.launch
+++ b/launch/start.launch
@@ -4,12 +4,14 @@
   <arg name="world_frame"/>
   <arg name="scanner_frame" />
   <arg name="scan_frequency" default="10.0" doc="Hz"/>
+  <arg name="z_out" value="true" doc="Flag to indicate whether the z-axis be oriented 'out' into the data like a camera (true), or if the data should be arrayed around the z-axis like a LiDAR scanner (false)"/>
 
   <node name="$(arg scanner_frame)" pkg="simulated_lidar_scanner" type="simulated_lidar_scanner_node" output="screen" clear_params="true">
     <rosparam command="load" file="$(arg params_file)"/>
     <param name="world_frame" value="$(arg world_frame)"/>
     <param name="scanner_frame" value="$(arg scanner_frame)"/>
     <param name="scan_frequency" value="$(arg scan_frequency)"/>
+    <param name="z_out" value="$(arg z_out)"/>
   </node>
 
 </launch>

--- a/src/lidar_scanner_node.cpp
+++ b/src/lidar_scanner_node.cpp
@@ -71,6 +71,7 @@ int main(int argc, char** argv)
     const std::string world_frame = get<std::string>(pnh, "world_frame");
     const std::string scanner_frame = get<std::string>(pnh, "scanner_frame");
     const ros::Rate rate(get<double>(pnh, "scan_frequency"));
+    const bool z_out = get<bool>(pnh, "z_out");
 
     // Get scanner parameters
     const ScannerParams sim = loadScannerParams(pnh);
@@ -80,7 +81,7 @@ int main(int argc, char** argv)
     tf2_ros::TransformListener listener(buffer);
 
     // Create scanner class
-    LidarScannerSim scanner(sim);
+    LidarScannerSim scanner(sim, z_out);
 
     // Create and set the scanner scene
     try
@@ -106,10 +107,8 @@ int main(int argc, char** argv)
       geometry_msgs::TransformStamped transform;
       try
       {
-        transform = buffer.lookupTransform(world_frame, scanner_frame, ros::Time(0));
-
         // Set scanner transform and dynamically changing elements of the scene
-        scanner.getNewScanData(tf2::transformToEigen(transform));
+        scanner.getNewScanData(tf2::transformToEigen(buffer.lookupTransform(world_frame, scanner_frame, ros::Time(0))));
         pcl::PointCloud<pcl::PointNormal>::Ptr data = scanner.getScanDataPointCloud();
 
         // Convert scan data from private class object to ROS msg

--- a/src/synthetic_lidar_scanner/vtkLidarScanner.cxx
+++ b/src/synthetic_lidar_scanner/vtkLidarScanner.cxx
@@ -418,28 +418,6 @@ void vtkLidarScanner::AcquirePoint(const unsigned int thetaIndex, const unsigned
   // so we have to apply the scanner's transform to the ray before casting it
   vtkSmartPointer<vtkRay> ray = this->Scan->GetValue(phiIndex, thetaIndex)->GetRay();
 
-  // std::cout << "Transform: " << *Transform << std::endl;
-
-  // vtkSmartPointer<vtkTransform> tempTransform = vtkSmartPointer<vtkTransform>::New();
-  //   InverseTransform->DeepCopy(Transform);
-  //   InverseTransform->Inverse();
-  //   std::cout << "inverted transform: " << *InverseTransform << std::endl;
-  //   ray->ApplyTransform(InverseTransform);
-  //   std::cout << "Applied transform." << std::endl;
-
-  {
-    double origin[3];
-    double direction[3];
-    ray->GetOrigin(origin);
-    ray->GetDirection(direction);
-    //     std::cout << "Ray: " << " origin: " << origin[0] << " " << origin[1] << " " << origin[2]
-    //               << " direction: " << direction[0] << " " << direction[1] << " " << direction[2] << std::endl;
-
-    double* scannerOrigin = this->Transform->GetPosition();
-    // std::cout << "scannerOrigin: " << scannerOrigin[0] << " " << scannerOrigin[1] << " " << scannerOrigin[2] <<
-    // std::endl;
-  }
-
   double t;
   double x[3];
   double pcoords[3];
@@ -531,7 +509,6 @@ void vtkLidarScanner::AcquirePoint(const unsigned int thetaIndex, const unsigned
 void vtkLidarScanner::PerformScan()
 {
   //  std::cout << "Performing scan..." << std::endl;
-
   this->MakeSphericalGrid();
 
   // Apply the transform to each ray
@@ -541,23 +518,11 @@ void vtkLidarScanner::PerformScan()
     {
       vtkSmartPointer<vtkRay> ray = this->Scan->GetValue(phi, theta)->GetRay();
       ray->ApplyTransform(this->Transform);
-    }
-  }
 
-  // Loop through the grid and intersect each ray with the scene.
-  unsigned int numberOfMisses = 0;
-  for (unsigned int theta = 0; theta < this->NumberOfThetaPoints; theta++)
-  {
-    for (unsigned int phi = 0; phi < this->NumberOfPhiPoints; phi++)
-    {
+      // intersect the ray with the scene.
       AcquirePoint(theta, phi);
-      if (!this->Scan->GetValue(phi, theta)->GetHit())
-      {
-        numberOfMisses++;
-      }
     }
   }
-  //  std::cout << "There were " << numberOfMisses << " misses." << std::endl;
 }
 
 void vtkLidarScanner::MakeSphericalGrid()

--- a/src/synthetic_lidar_scanner/vtkLidarScanner.cxx
+++ b/src/synthetic_lidar_scanner/vtkLidarScanner.cxx
@@ -69,12 +69,18 @@ double* vtkLidarScanner::GetLocation() const
 
 double vtkLidarScanner::GetPhiStep() const
 {
-  return fabs(MaxPhiAngle - MinPhiAngle) / static_cast<double>(NumberOfPhiPoints - 1);
+  if (NumberOfPhiPoints > 1)
+    return fabs(MaxPhiAngle - MinPhiAngle) / static_cast<double>(NumberOfPhiPoints - 1);
+  else
+    return 0.0;
 }
 
 double vtkLidarScanner::GetThetaStep() const
 {
-  return fabs(MaxThetaAngle - MinThetaAngle) / static_cast<double>(NumberOfThetaPoints - 1);
+  if (NumberOfThetaPoints > 1)
+    return fabs(MaxThetaAngle - MinThetaAngle) / static_cast<double>(NumberOfThetaPoints - 1);
+  else
+    return 0.0;
 }
 
 double vtkLidarScanner::GetNumberOfTotalPoints() const


### PR DESCRIPTION
- Minor bug fixes
- Adds a flag `z_out` to optionally rotate the simulated LiDAR scanner 90 degrees such that the sensor z-axis points out towards the data like a camera. When this flag is set to false, the data will be arrayed around the z-axis like a traditional LiDAR sensor